### PR TITLE
Fixed bug that broke the extension directory on Windows machines

### DIFF
--- a/html/include/phpinfo-scanner.php
+++ b/html/include/phpinfo-scanner.php
@@ -108,7 +108,7 @@ class xdebugVersion
 		}
 		else 
 		{
-			if (preg_match( '/extension_dir([ =>\t]*)([^ =>\t]+)/', $data, $m ) )
+			if (preg_match( '/extension_dir([ =>\t]*)([^=>\t]+)/', $data, $m ) )
 			{
 				$this->extensionDir = $m[2];
 			}


### PR DESCRIPTION
Fixed bug that broke the extension directory on Windows machines.  (Anyone know of any other issues this might cause by accepting spaces here?)
