### PR TITLE
Update features.php to mention FPM as a case of FastCGI for port 9000 conflicts.

### DIFF
--- a/html/docs/include/features.php
+++ b/html/docs/include/features.php
@@ -1302,7 +1302,8 @@ the necessary information to your URL. See the
 more information.</dd>
 <dd>A: Have you checked your firewall settings? Make sure the port Xdebug is
 listening on (default 9000) is not blocked.</dd>
-<dd>A: Are you using FastCGI? It uses the same port by default as Xdebug (9000)
+<dd>A: Are you using FastCGI, maybe via FPM (FastCGI Process Manager)? 
+  It uses the same port by default as Xdebug (9000)
 so you will need to change one of them to a different number. In Xdebug you can
 do that with [CFG:xdebug.remote_port].</dd>
 <dd>A: If you are running with SELinux you should make sure it is not


### PR DESCRIPTION
Suggest FPM as a case of FastCGI, mostly to make FPM visible to search engines users searching for this information.
