### PR TITLE
Tweaked the version detection regex to accept PHP v7

### DIFF
--- a/html/include/phpinfo-scanner.php
+++ b/html/include/phpinfo-scanner.php
@@ -36,7 +36,7 @@ class xdebugVersion
 			$this->sapi = trim( $m[2] );
 		}
 
-		if ( preg_match( '/PHP Version([^45]+)([45][0-9.dev-]+)/', $data, $m ) )
+		if ( preg_match( '/PHP Version([^457]+)([457][0-9.dev-]+)/', $data, $m ) )
 		{
 			$this->version = $m[2];
 		}


### PR DESCRIPTION
Now that PHP v7.0 has been released, I thought it'd be helpful if the scanner supported it.  :smiley: 