### PR TITLE
Change Travis Badge to point to its real location

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -9,7 +9,7 @@
 
 <?php include "include/menu.php"; ?>
 
-<img src='https://travis-ci.org/xdebug/xdebug.svg?branch=master'/>
+<img src='https://api.travis-ci.org/xdebug/xdebug.svg?branch=master'/>
 <img src='https://ci.appveyor.com/api/projects/status/glp9xfsmt1p25nkn?svg=true'/>
 
 <a name="about"></a>


### PR DESCRIPTION
The current URL leads to an 301, which is not needed.