### PR TITLE
Remove the brew instructions for the mac

### DIFF
--- a/html/docs/include/features.php
+++ b/html/docs/include/features.php
@@ -60,27 +60,11 @@ zend_extension=\"/usr/local/php/modules/xdebug.so\"
 php.ini &mdash; this <b>will</b> cause problems.</p>
 
 <a name='mac'></a>
-<h2>Installation on Mac OS X via Homebrew</h2>
+<h2>Installation on Mac OS X</h2>
 
 <p>
-PHP and Xdebug are available from the unofficial Mac OS X package manager <a href='http://brew.sh/'>Homebrew</a>. If you use PHP installed via Homebrew (see <a href=\"https://github.com/Homebrew/homebrew-php#installation\">this installation guide</a> for details on how to do that)  Xdebug can be installed via brew install:
+PHP is available from the unofficial Mac OS X package manager <a href='http://brew.sh/'>Homebrew</a>. Homebrew recommend using PECL to install Xdebug, so please follow the instructions above for <a href="#pecl">installing via PECL</a>.
 </p>
-<pre class='example'>
-# brew install homebrew/php/&lt;php-version&gt;-xdebug
-</pre>
-<p>
-eg.
-</p>
-<pre class='example'>
-# brew install homebrew/php/php71-xdebug
-</pre>
-<p>
-You can also use brew search to locate the specific package you need:
-</p>
-<pre class='example'>
-# brew search xdebug
-</pre>
-<p>The Xdebug extension will be enabled per default after the installation, additional configuration of the extension should be done by adding a custom ini-file to /usr/local/etc/php/&lt;php-version&gt;/conf.d/ . See the Caveats output at the end of the installation for more details.</p>
 
 <a name='source'></a>
 <h2>Installation From Source</h2>


### PR DESCRIPTION
Homebrew recommend we install Xdebug via pecl and not via brew

https://brew.sh/2018/01/19/homebrew-1.5.0/