### PR TITLE
Remove irrelevant step for Firefox on Linux

### DIFF
--- a/html/docs/include/settings.php
+++ b/html/docs/include/settings.php
@@ -696,8 +696,6 @@ For various IDEs/OSses there are some instructions listed on how to make this wo
 </p>
 <h4>Firefox on Linux</h4>
 <ul>
-<li>Open <a href="about:config">about:config</a></li>
-<li>Add a new boolean setting "network.protocol-handler.expose.xdebug" and set it to "false"</li>
 <li>Add the following into a shell script <code>~/bin/ff-xdebug.sh</code>:
 <pre>
 #! /bin/sh


### PR DESCRIPTION
According to
http://kb.mozillazine.org/Network.protocol-handler.expose.%28protocol%29
there is a 'network.protocol-handler.expose-all' setting with default
value of true, which overrides any other
'network.protocol-handler.expose.*' settings. Therefore it is not needed
to use 'about:config' in FireFox.