### PR TITLE
Fix link for garbage collection

### DIFF
--- a/data/news/2018-01-22.txt
+++ b/data/news/2018-01-22.txt
@@ -1,7 +1,7 @@
 Xdebug 2.6.0RC1 is out!
 <p>This is the first, and likely last, release candidate of Xdebug 2.6.0. The
 major change in this release is the addition of
-<a href="/docs/garbage_collection">Garbage Collection</a> statistics
+<a href="/docs/garbage_collection_statistics">Garbage Collection</a> statistics
 functionality, contributed by Benjamin Eberlei.</p>
 
 <p>Besides this addition, several bug fixes to Xdebug's remote debugging and

--- a/data/news/2018-01-29.txt
+++ b/data/news/2018-01-29.txt
@@ -10,7 +10,7 @@ features, as you can see on the <a href="/updates.php#x_2_6_0">updates</a>
 page. A few highlights are: <b>support for profiling memory usage</b>,
 <a href="https://xdebug.org/docs/stack_trace#filename_format">configurable
 formatting of filenames</a>, statistics of PHP's <a
-href="https://xdebug.org/docs/garbage_collection">Garbage Collector</a>, and
+href="https://xdebug.org/docs/garbage_collection_statistics">Garbage Collector</a>, and
 for the "remote" debugger:
 "Notice" and "Warning" notifications are sent to the IDE, support for
 low-ASCII characters in property names and array keys, support for NULL

--- a/html/router.php
+++ b/html/router.php
@@ -19,7 +19,7 @@ if ($requested_uri === '/') {
 } elseif (preg_match('/^\/docs(\/([a-z_]+))?/', $requested_uri, $matches)) {
 	$pages = [
 		'install', 'basic', 'display', 'stack_trace', 'execution_trace',
-		'profiler', 'remote', 'code_coverage', 'compat', 'faq', 'dbgp',
+		'profiler', 'remote', 'code_coverage', 'garbage_collection_statistics', 'compat', 'faq', 'dbgp',
 	];
 
 	if (isset($matches[2])) {

--- a/html/router.php
+++ b/html/router.php
@@ -19,7 +19,8 @@ if ($requested_uri === '/') {
 } elseif (preg_match('/^\/docs(\/([a-z_]+))?/', $requested_uri, $matches)) {
 	$pages = [
 		'install', 'basic', 'display', 'stack_trace', 'execution_trace',
-		'profiler', 'remote', 'code_coverage', 'garbage_collection_statistics', 'compat', 'faq', 'dbgp',
+		'profiler', 'remote', 'code_coverage', 'garbage_collection_statistics', 
+		'compat', 'faq', 'dbgp',
 	];
 
 	if (isset($matches[2])) {

--- a/views/home/updates.php
+++ b/views/home/updates.php
@@ -180,7 +180,7 @@ function issue(int $nr) : string {
 
 <dd><h3>Added features</h3></dd>
 
-<dd>Fixed <?= bug(1506); ?>: Add <a href="/docs/garbage_collection">garbage collection</a> statistics feature (Benjamin Eberlei).</dd>
+<dd>Fixed <?= bug(1506); ?>: Add <a href="/docs/garbage_collection_statistics">garbage collection</a> statistics feature (Benjamin Eberlei).</dd>
 <dd>Fixed <?= bug(1507); ?>: Add functions to access Zend Engine garbage collection metrics (Benjamin Eberlei).</dd>
 
 <dd><h3>Improvements</h3></dd>


### PR DESCRIPTION
On https://xdebug.org/docs/ the link for Garbage Collection Statistics https://xdebug.org/docs/garbage_collection runs into 404