### PR TITLE
Ignore some Psalm issues, fix one other

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -14,4 +14,12 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+
+    <issueHandlers>
+        <InvalidScope>
+            <errorLevel type="suppress">
+                <file name="views/fourohfour/404.php" />
+            </errorLevel>
+        </InvalidScope>
+    </issueHandlers>
 </psalm>

--- a/src/Controller/SupportController.php
+++ b/src/Controller/SupportController.php
@@ -98,7 +98,7 @@ class SupportController
 			{
 				$totalHours[$type] = 0;
 			}
-			$totalHours[$type] += $hours;
+			$totalHours[$type] += (float) $hours;
 		};
 
 		krsort($totalHours);

--- a/src/Model/SupportLogMonthReport.php
+++ b/src/Model/SupportLogMonthReport.php
@@ -18,7 +18,7 @@ class SupportLogMonthReport
 
 	/**
 	 * @param array<SupportLogDayReport>  $days
-	 * @param array<string, string>  $totalHours
+	 * @param array<string, float>  $totalHours
 	 */
 	public function __construct(
 		\DateTimeImmutable $start,

--- a/views/docs/section.php
+++ b/views/docs/section.php
@@ -4,6 +4,7 @@
  */
 XdebugDotOrg\Controller\TemplateController::setTitle('Xdebug: Documentation » ' . $this->title);
 
+/** @psalm-suppress UndefinedThisPropertyFetch because of slight cheats */
 XdebugDotOrg\Controller\TemplateController::setHeadExtra(
 	XdebugDotOrg\Controller\DocsController::sectionHead($this->model)->render()
 );


### PR DESCRIPTION
Note to self: IN THE FUTURE Psalm should have a better way to represent what's actually happening in these view files by supporting `@mixin<T>` and using annotations like:

```php
/**
 * @psalm-scope-this XdebugDotOrg\Core\HtmlResponse<XdebugDotOrg\Model\DocsSection>
 */
```

In the meantime, here are fixes to suppress Psalm's errors.