### PR TITLE
Added note to dbgpClient doc when it fails to start on Linux

### DIFF
--- a/html/docs/include/features/dbgpClient.html
+++ b/html/docs/include/features/dbgpClient.html
@@ -72,6 +72,9 @@ and then run:</p>
 ./dbgpClient
 </pre>
 
+<p>Note: If the command fails with error No such file or directory, install the
+libc6-i386 package as dbgpClient is a 32-bit application. </p>
+
 <p>To start the client on the command line on MacOS, open a shell,
 and then run:</p>
 


### PR DESCRIPTION
Hi Derick,

I noted the following issue on Alpine Linux docker image when I tried to run dbgpClient

$ ./dbgpClient
zsh: no such file or directory: ./dbgpClient

I was at loss, but this [thread](https://stackoverflow.com/questions/2716702/no-such-file-or-directory-error-when-executing-a-binary) helped me figure it out therefore I added a note to the documentation for other users on how to fix that.
