### PR TITLE
docs: fix typos

### DIFF
--- a/html/docs/include/features/dbgp.html
+++ b/html/docs/include/features/dbgp.html
@@ -2817,7 +2817,7 @@ status is returned unless the mode in the
 command was zero, in which case the
 status will be up to the debugger engine
 (typically the last status before running
-interact), or some error has occured
+interact), or some error has occurred
 that causes a different status.</td>
 </tr>
 <tr><td>CONTINUE_FLAG</td>

--- a/html/docs/include/features/execution_trace.html
+++ b/html/docs/include/features/execution_trace.html
@@ -142,7 +142,7 @@ On the "collect_return=1" tab the return values of all the function calls are
 also visible.  This you turn on with the [CFG:collect_return] setting.
 </p>
 <p>
-The tab called "collect_assignments=1" shows variable assigments, which can be
+The tab called "collect_assignments=1" shows variable assignments, which can be
 turned on with the [CFG:collect_assignments] setting.
 </p>
 <p>

--- a/html/docs/include/settings/dump.asterix.html
+++ b/html/docs/include/settings/dump.asterix.html
@@ -1,7 +1,7 @@
 <p>* can be any of COOKIE, FILES, GET, POST, REQUEST, SERVER, SESSION.
 These seven settings control which data from the superglobals is shown when an
 error situation occurs.</p>
-<p>Each of those php.ini setting can consist of a comma seperated list of
+<p>Each of those php.ini setting can consist of a comma separated list of
 variables from this superglobal to dump, or <code>*</code> for all of them.
 Make sure you do not add spaces in this setting.</p>
 <p>In order to dump the REMOTE_ADDR and the REQUEST_METHOD when an error

--- a/html/docs/include/settings/remote_log.html
+++ b/html/docs/include/settings/remote_log.html
@@ -8,7 +8,7 @@ running with Apache) can create and write to the file.</p>
 and will therefore not be overwritten by default. There is no concurrency
 protection available.</p>
 
-<p>When succesfully enabled, the log file will include any attempt that Xdebug
+<p>When successfully enabled, the log file will include any attempt that Xdebug
 makes to connect to an IDE:</p>
 
 <pre>


### PR DESCRIPTION
Hey,

This tiny PR will fix : 

- 1 typo in `html/docs/include/features/dbgp.html`
- 1 typo in `html/docs/include/features/execution_trace.html`
- 1 typo in `html/docs/include/settings/dump.asterix.html`
- 1 typo in `html/docs/include/settings/remote_log.html`



Ciao! :robot: