### PR TITLE
Clarify relationship between env and ini mode

### DIFF
--- a/html/docs/include/settings/mode.html
+++ b/html/docs/include/settings/mode.html
@@ -42,5 +42,6 @@ during a request to a file.</dd>
 <p>You can enable multiple modes at the same time by comma separating their
 identifiers as value to [CFG:mode]: <code>xdebug.mode=develop,trace</code>.</p>
 
-<p>You can override [CFG:mode] on the command line by setting the
-<code>XDEBUG_MODE</code> environment variable.</p>
+<p>You can also set the mode by setting the <code>XDEBUG_MODE</code> environment
+variable on the command-line; this will take precedence over the [CFG:mode] 
+setting.</p>


### PR DESCRIPTION
On [this question on Stack Overflow](https://stackoverflow.com/q/65107145/157957), a user was confused that setting `XDEBUG_MODE` didn't change the value of the `xdebug.mode` ini setting. As far as I can see, that's intentional, and the actual setting was taking effect as expected, but the wording here was a bit ambiguous.