### PR TITLE
Fixes when two link tags are on the same line

### DIFF
--- a/src/Controller/DocsController.php
+++ b/src/Controller/DocsController.php
@@ -156,7 +156,7 @@ debug control flow and examine data structures.",
 		$text = preg_replace( '/\[CFG:([^\]]*?)\]/', '<a href="/docs/all_settings#\1">xdebug.\1</a>', $text );
 		$text = preg_replace( '/\[CFGS:([^\]]*?)\]/', '<a href="/docs/all_settings#\1">\1</a>', $text );
 		$text = preg_replace_callback(
-			'/\[FEAT:([^\]]*?)(#.*)?\]/',
+			'/\[FEAT:([^\]]*?)(#[^\]]*)?\]/',
 			function (array $matches) {
 				if (!array_key_exists(2, $matches)) {
 					$matches[2] = '';
@@ -176,7 +176,7 @@ debug control flow and examine data structures.",
 		$text = preg_replace( '/\[CFG:([^\]]*?)\]/', 'xdebug.\1', $text );
 		$text = preg_replace( '/\[CFGS:([^\]]*?)\]/', '\1', $text );
 		$text = preg_replace_callback(
-			'/\[FEAT:([^\]]*?)(#.*)?\]/',
+			'/\[FEAT:([^\]]*?)(#[^\]]*)?\]/',
 			function (array $matches) {
 				if (!array_key_exists(2, $matches)) {
 					$matches[2] = '';


### PR DESCRIPTION
This patch will fixes the link render results when two link tags are on the same line, that one link tag include hash.

eg:

```
[FEAT:develop#stack_trace] and [FEAT:trace]
```

BEFORE:

```
<a href="/docs/develop#stack_trace] and [FEAT:trace">Development Aids</a>
```

AFTER:

```
<a href="/docs/develop#stack_trace">Development Aids</a> and <a href="/docs/trace">Function Trace</a>
```

