### PR TITLE
Avoid recommending partial updates while installing xdebug on Arch Linux

### DIFF
--- a/html/docs/include/features/install.html
+++ b/html/docs/include/features/install.html
@@ -15,7 +15,7 @@ How you install Xdebug depends on your system. There are the following possibili
 Installing Xdebug with a package manager is often the fastest way. Depending on your distribution, run the following command:
 <ul>
 	<li><strong>Alpinelinux</strong>:<br/><code>sudo apk add php7-pecl-xdebug</code></li>
-	<li><strong>Arch Linux</strong>:<br/><code>sudo pacman -Sy xdebug</code></li>
+	<li><strong>Arch Linux</strong>:<br/><code>sudo pacman -S xdebug</code></li>
 	<li><strong>CentOS</strong>:<br/><code>sudo yum install php-xdebug</code></li>
 	<li><strong>CentOS</strong> (Remi Repro):<br/><code>sudo yum install php74-php-xdebug</code></li>
 	<li><strong>Debian</strong> (9/stretch, testing/buster/bullseye/sid):<br/><code>sudo apt-get install php-xdebug</code></li>


### PR DESCRIPTION
[Partial upgrades of packages are not supported on Arch Linux](https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported)

This change suggest installing `xdebug` without refreshing packages. An alternative would be suggesting `pacman -Syu xdebug`, which upgrades the whole system while installing `xdebug`.