### PR TITLE
correct trigger name for profiling

### DIFF
--- a/html/docs/include/features/profiler.html
+++ b/html/docs/include/features/profiler.html
@@ -56,7 +56,7 @@ like <a href="http://ez.no">eZ Publish</a>.</p>
 <p>You can also selectively enable the profiler by setting
 [CFG:start_with_request#trigger] to <code>trigger</code>. You can then enable
 the profiler by using an environment value, a GET/POST parameter, or COOKIE
-variable of the name <code>XDEBUG_SESSION</code>. The FireFox and Chrome
+variable of the name <code>XDEBUG_TRIGGER</code>. The FireFox and Chrome
 extensions that can be used to enable the step debugger (see
 <a href="/docs/remote#firefox-ext">HTTP Debug Sessions</a>) can also be used
 with this setting.</p>


### PR DESCRIPTION
Noticed on [profiler page](https://xdebug.org/docs/profiler):

> You can then enable the profiler by using an environment value, a GET/POST parameter, or COOKIE variable of the name `XDEBUG_SESSION`.

Which conflicts with info on [trigger page](https://xdebug.org/docs/all_settings#start_with_request#trigger):

> The name of the trigger is XDEBUG_TRIGGER, and Xdebug checks for its presence in either $_ENV (environment variable), $_GET or $_POST variable, or $_COOKIE (HTTP cookie name).
> 
> There is also a legacy fallback to a functionality specific trigger name: XDEBUG_PROFILE (for Profiling), XDEBUG_TRACE (for a Function Trace), and XDEBUG_SESSION (for Step Debugging).

So, seems using legacy variable, but even then, the one for step debugging vs profiling.

This is just going by the docs, I haven't tested functionality.

PR updates to

> You can then enable the profiler by using an environment value, a GET/POST parameter, or COOKIE variable of the name `XDEBUG_TRIGGER`.