### PR TITLE
fix(docs): typo in compat.html

### DIFF
--- a/html/docs/include/features/compat.html
+++ b/html/docs/include/features/compat.html
@@ -58,7 +58,7 @@ needs for compression of profile and trace files.</p>
 <dt>DBG, APD, ioncube etc</dt>
 <dd>
 	<p>Xdebug does <b>not</b> work together with other extensions
-	hat deal with PHP's internals. This is due to
+	that deal with PHP's internals. This is due to
 	compatibility problems with those modules.</p>
 </dd>
 </dl>


### PR DESCRIPTION
Fix missing "t" in "that".  