### PR TITLE
Update wizard to add trailing slash to target dir for cp xdebug.so 

### DIFF
--- a/views/wizard/result.php
+++ b/views/wizard/result.php
@@ -119,7 +119,7 @@ Zend Extension Api No:   <?= $this->x->zendApi ?>
             </li>
             <li>Run: <code>./configure</code></li>
 			<li>Run: <code>make</code></li>
-			<li>Run: <code>cp modules/xdebug.so <?= $this->x->extensionDir ?></code></li>
+			<li>Run: <code>cp modules/xdebug.so <?= $this->x->extensionDir ?>/</code></li>
 		<?php endif ?>
 	<?php else : ?>
 		<li>Move the downloaded file to <?= $this->x->extensionDir ?>, and rename it to <code>php_xdebug.dll</code></li>


### PR DESCRIPTION
On macOS, the target directory suggested by the wizard does not always exist. 

```
8. Run: cp modules/debug.so /opt/homebrew/lib/php/pec1/20220829
```

Running `cp` without a trailing slash results in the file being copied to a file with the name of the directory (ie `20220829`), instead of being copied _into_ such a directory with its proper name. With the trailing slash, it will complain that the directory doesn't exist, and then the user can know to mkdir the folder.