### PR TITLE
Update Arch Linux package URL in install.html

### DIFF
--- a/html/docs/include/features/install.html
+++ b/html/docs/include/features/install.html
@@ -18,7 +18,7 @@ Installing Xdebug with a package manager is often the fastest way. Depending on 
 		<code>sudo apk add php7-pecl-xdebug</code>, or <br/>
 		<code>sudo apk add <a href='https://pkgs.alpinelinux.org/packages?name=php8-pecl-xdebug&branch=edge'>php8-pecl-xdebug</a></code>
 	</li>
-	<li><strong>Arch Linux</strong>:<br/><code>sudo pacman -S <a href='https://archlinux.org/packages/community/x86_64/xdebug/'>xdebug</a></code></li>
+	<li><strong>Arch Linux</strong>:<br/><code>sudo pacman -S <a href='https://archlinux.org/packages/extra/x86_64/xdebug/'>xdebug</a></code></li>
 	<li><strong>CentOS</strong>:<br/><code>sudo yum install <a href='https://rpmfind.net/linux/rpm2html/search.php?query=php-xdebug(x86-64)'>php-xdebug</a></code></li>
 	<li><strong>CentOS</strong> (Remi Repo):<br/>
 		<code>sudo yum install php74-php-xdebug3</code>, or<br/>


### PR DESCRIPTION
The old URL returns 404 now.