### PR TITLE
Update remote_port setting name in dbgpClient docs

### DIFF
--- a/html/docs/include/features/dbgpClient.html
+++ b/html/docs/include/features/dbgpClient.html
@@ -26,7 +26,7 @@ You only have to download the binary, which you can then run from a command line
 <tr><td><code>-p&nbsp;value</code>&nbsp;</td>
      <td>Specify the port to listen on [<code>9003</code>]. This is the same
          port that Xdebug should initiate a connection on. On the Xdebug side,
-         this port can be configured with the [CFG:remote_port]
+         this port can be configured with the [CFG:client_port]
          setting.</td></tr>
 
 <tr><td><code>-r&nbsp;idekey</code>&nbsp;</td>


### PR DESCRIPTION
I'm guessing that this should be `client_port` instead of `remote_port` in the docs because:

* `remote_port` was renamed in Xdebug 3
*  the `client_port` documentation references `dbgpClient` (https://github.com/xdebug/xdebug.org/blob/2633894733e6a43e10e6f450ad43739f98b0d552/html/docs/include/settings/client_port.html#L2C64-L2C74).