### PR TITLE
#134 Replace WinCacheGrind with QCacheGrind

### DIFF
--- a/src/Controller/DocsController.php
+++ b/src/Controller/DocsController.php
@@ -64,7 +64,7 @@ class DocsController
 			\FUNC_PROFILER,
 			'Xdebug\'s built-in profiler allows you to find bottlenecks in your
 			script and visualize those with an external tool such as KCacheGrind or
-			WinCacheGrind.',
+			QCacheGrind.',
 		],
 		'remote' => [
 			'Step Debugging',


### PR DESCRIPTION
Replaces outdated WinCacheGrind mention in intro blurb with QCacheGrind (which is later also mentioned in the text).