### PR TITLE
Add LaraDumps as the third-party clients to debug with step debugging

### DIFF
--- a/html/docs/include/features/step_debug.html
+++ b/html/docs/include/features/step_debug.html
@@ -210,6 +210,7 @@ support:
 <li><b><a href="https://packagecontrol.io/packages/Xdebug%20Client">SublimeTextXdebug</a></b> (Plugin for Sublime Text 2 and 3, Open Source).</li>
 <li><b>VIM <a href="https://github.com/joonty/vdebug">plugin</a></b> (Plugin; Open Source).</li>
 <li><b>VS Code <a href="https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug">plugin</a></b> (Plugin; Open Source).</li>
+<li><a href="https://laradumps.dev">LaraDumps</a> (Debug tool: Windows, Linux, Mac; Open source).</li>	
 </ul>
 </p>
 <p>


### PR DESCRIPTION
Add LaraDumps as the third-party clients to debug with step debugging

https://laradumps.dev/debug/xdebug.html