### PR TITLE
Update XDebug Chrome extension

### DIFF
--- a/html/docs/include/features/step_debug.html
+++ b/html/docs/include/features/step_debug.html
@@ -99,8 +99,8 @@ The extensions are:
 	(<a href="https://github.com/BrianGilbert/xdebug-helper-for-firefox">source</a>).
 </li>
 <li>
-	<a href="https://chrome.google.com/extensions/detail/eadndfjplgieldjbigjakmdgkmoaaaoc">Xdebug Helper for Chrome</a>
-	(<a href="https://github.com/mac-cain13/xdebug-helper-for-chrome">source</a>).
+	<a href="https://chromewebstore.google.com/detail/xdebug-helper-by-jetbrain/aoelhdemabeimdhedkidlnbkfhnhgnhm">Xdebug Helper for Chrome</a>
+	(<a href="https://github.com/JetBrains/xdebug-extension">source</a>).
 </li>
 <li>
 	<a href="https://apps.apple.com/app/safari-xdebug-toggle/id1437227804?mt=12">XDebugToggle for Safari</a>


### PR DESCRIPTION
The Chrome extension referenced in the documentation is no longer supported.
JetBrains has forked this extension and published a new, maintained version.
IMHO, this should be the recommended extension.