### PR TITLE
:memo: Add pseudo hosts for xdebug.client_host

### DIFF
--- a/html/docs/include/settings/client_host.html
+++ b/html/docs/include/settings/client_host.html
@@ -1,10 +1,13 @@
 <p>Configures the IP address or hostname where Xdebug will attempt to connect to when initiating a
 debugging connection. This address should be the address of the machine where your IDE or debugging
 client is listening for incoming debugging connections.</p>
-<p>On non-Windows platforms, it is also possible to configure a <a
-href="https://en.wikipedia.org/wiki/Unix_domain_socket">Unix domain socket</a> which is supported by
-only a select view debugging clients. In that case, instead of the hostname or IP address, use
-<code>unix:///path/to/sock</code>.</p>
+<p>Pseudo hosts are available to use in-place of an IP:</p>
+<ul>
+  <li><code>xdebug://gateway</code>: use the system defined network gateway.</li>
+  <li><code>xdebug://nameserver</code>: use the system defined private network nameserver.</li>
+  <li><code>unix:///path/to/sock</code>: On non-Windows platforms, supported by only a select view debugging clients,
+    use a <a href="https://en.wikipedia.org/wiki/Unix_domain_socket">Unix domain socket</a>.</li>
+</ul>
 <p>If [CFG:discover_client_host] is enabled then Xdebug will only use the value of this setting in
 case Xdebug can not connect to an IDE using the information it obtained from HTTP headers. In that
 case, the value of this setting acts as a fallback only.</p>


### PR DESCRIPTION
Following https://github.com/xdebug/xdebug/pull/833 xdebug configuration now allows xdebug://gateway and xdebug://nameserver pseudo hosts, those should be documented.

![image](https://github.com/user-attachments/assets/b87969e8-0ac7-4fb9-b72c-2b1212de1364)
